### PR TITLE
Update to be compatible with Zig 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const zipf = @import("zipf");
 pub fn main() !void {
     var prng = std.rand.DefaultPrng.init(blk: {
         var seed: u64 = undefined;
-        try std.os.getrandom(std.mem.asBytes(&seed));
+        try std.posix.getrandom(std.mem.asBytes(&seed));
         break :blk seed;
     });
     const rand = prng.random();
@@ -37,20 +37,25 @@ pub fn main() !void {
 ### Add the Library with Zon
 
 1. Declare zig zipf as a dependency in build.zig.zon: 
-
-```
+```zig
 .dependencies = .{
     .zipf = .{
-        .url = "https://github.com/toziegler/zig-zipf/archive/refs/tags/v1.0.tar.gz",
-            .hash = "122003ade97e0a690c28fb264aeedf6958ec57ee94087438dd6d1e7dbcffc7dab461",
+        // This can be found by navigating to
+        // https://github.com/toziegler/zig-zipf/releases and obtaining the
+        // link to the tar file for the latest release.
+        .url = "https://github.com/toziegler/zig-zipf/archive/refs/tags/<latest release>.tar.gz",
+        .hash = "<latest release hash>"
+        // You may also leave out the .hash field. This will cause `zig build`
+        // to tell you the correct hash when you go to build your project, and
+        // you can include it here.
     },
 },
 ```
+Release Hashes:
+* v1.0: `122003ade97e0a690c28fb264aeedf6958ec57ee94087438dd6d1e7dbcffc7dab461`
 
 2. Add the module in `build.zig`
-
 ```diff
-
     const exe = b.addExecutable(.{
         .name = "zigzipfexample",
         .root_source_file = .{ .path = "src/main.zig" },
@@ -58,12 +63,12 @@ pub fn main() !void {
         .optimize = optimize,
     });
 
-+   const opts = .{ .target = target, .optimize = optimize };
-+   const zipf = b.dependency("zipf", opts).module("zipf");
-+   exe.addModule("zipf", zipf);
++   const zipf = b.dependency("zipf", .{
++       .target = target,
++       .optimize = optimize,
++   });
++   exe.root_module.addImport("zipf", zipf.module("zipf"));
 ```
-
-
 
 ### Add the Library with Git Submodules
 
@@ -88,5 +93,5 @@ pub fn main() !void {
         .target = target,
         .optimize = optimize,
     });
-    exe.addModule("zipf", zipf.module("zipf"));
+    exe.root_module.addImport("zipf", zipf.module("zipf"));
     ```

--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,12 @@ pub fn build(b: *std.Build) void {
     });
 
     b.installArtifact(lib);
-    const zipf = b.addModule("zipf", .{ .source_file = .{ .path = "src/root.zig" } });
+
+    const zipf = b.addModule("zipf", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe = b.addExecutable(.{
         .name = "zipf",
@@ -22,7 +27,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    exe.addModule("zipf", zipf);
+    exe.root_module.addImport("zipf", zipf);
 
     b.installArtifact(exe);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,7 +4,7 @@ const zipf = @import("zipf");
 pub fn main() !void {
     var prng = std.rand.DefaultPrng.init(blk: {
         var seed: u64 = undefined;
-        try std.os.getrandom(std.mem.asBytes(&seed));
+        try std.posix.getrandom(std.mem.asBytes(&seed));
         break :blk seed;
     });
     const rand = prng.random();

--- a/src/root.zig
+++ b/src/root.zig
@@ -240,7 +240,7 @@ const S = struct {
 
         var prng = std.rand.DefaultPrng.init(blk: {
             var seed: u64 = undefined;
-            try std.os.getrandom(std.mem.asBytes(&seed));
+            try std.posix.getrandom(std.mem.asBytes(&seed));
             break :blk seed;
         });
         const rand = prng.random();


### PR DESCRIPTION
Hi!

I just went to use zig-zipf and it turned out some of the stuff in `build.zig` was outdated, as was the use of `std.os.getrandom` in `root.zig` and `main.zig`. I believe I fixed everything so that it should work with 0.12.0. I also changed the README.md to update the build syntax there and I made the part about the `build.zig.zon` file a bit more generic, supposing that if you accept these changes, you might make a new release.

Best,
Matthew